### PR TITLE
Fixed errors while compilling. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 project(monitor)
 
 find_package(Curses REQUIRED)

--- a/include/all_processes.h
+++ b/include/all_processes.h
@@ -1,10 +1,10 @@
 #ifndef ALL_PROCESSES_H
 #define ALL_PROCESSES_H
 
-#include "process.h"
-
 #include <string>
 #include <vector>
+
+#include "process.h"
 
 using std::string;
 using std::vector;

--- a/include/system.h
+++ b/include/system.h
@@ -4,20 +4,20 @@
 #include <string>
 #include <vector>
 
+#include "all_processes.h"
 #include "process.h"
 #include "processor.h"
-#include "all_processes.h"
 
 class System {
  public:
-  Processor& Cpu();                  
-  All_Processes& Processes(); 
-  float MemoryUtilization();         
-  long UpTime();                     
-  int TotalProcesses();              
-  int RunningProcesses();            
-  std::string Kernel();              
-  std::string OperatingSystem();     
+  Processor& Cpu();
+  All_Processes& Processes();
+  float MemoryUtilization();
+  long UpTime();
+  int TotalProcesses();
+  int RunningProcesses();
+  std::string Kernel();
+  std::string OperatingSystem();
 
   // TODO: Define any necessary private members
  private:

--- a/src/all_processes.cpp
+++ b/src/all_processes.cpp
@@ -1,7 +1,10 @@
 #include "all_processes.h"
+
 #include <unistd.h>
+
 #include <algorithm>
 #include <vector>
+
 #include "linux_parser.h"
 #include "process.h"
 
@@ -65,4 +68,3 @@ void All_Processes::RemoveFinishedProcesses(bool& changed) {
     }
   }
 }
-

--- a/src/format.cpp
+++ b/src/format.cpp
@@ -1,4 +1,5 @@
 #include "format.h"
+
 #include <iomanip>
 #include <sstream>
 #include <string>

--- a/src/linux_parser.cpp
+++ b/src/linux_parser.cpp
@@ -1,9 +1,11 @@
+#include "linux_parser.h"
+
 #include <dirent.h>
+
 #include <sstream>
 #include <string>
 #include <vector>
 
-#include "linux_parser.h"
 #include "parser_consts.h"
 #include "parser_helper.h"
 
@@ -69,7 +71,6 @@ vector<int> LinuxParser::Pids() {
   return pids;
 }
 
-
 // Read and return the system memory utilization
 float LinuxParser::MemoryUtilization() {
   float memTotal = ParserHelper::GetValueByKey<int>(
@@ -82,7 +83,6 @@ float LinuxParser::MemoryUtilization() {
   return memory;
 }
 
-
 // Read and return the system uptime
 long LinuxParser::UpTime() {
   string line;
@@ -90,20 +90,17 @@ long LinuxParser::UpTime() {
   return upTime;
 }
 
-
 // Read and return the total number of processes
 int LinuxParser::TotalProcesses() {
   return ParserHelper::GetValueByKey<int>(ParserConsts::filterProcesses,
                                           ParserConsts::kStatFilename);
 }
 
-
 // Read and return the number of running processes
 int LinuxParser::RunningProcesses() {
   return ParserHelper::GetValueByKey<int>(ParserConsts::filterRunningProcesses,
                                           ParserConsts::kStatFilename);
 }
-
 
 // Read and return the user associated with a process
 string LinuxParser::UserByUID(int UID) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,9 +1,8 @@
 #include <iostream>
+
 #include "ncurses_display.h"
-#include "system.h"
 #include "process.h"
-
-
+#include "system.h"
 
 int main() {
   System system;

--- a/src/ncurses_display.cpp
+++ b/src/ncurses_display.cpp
@@ -1,11 +1,13 @@
+#include "ncurses_display.h"
+
 #include <curses.h>
+
 #include <chrono>
 #include <string>
 #include <thread>
 #include <vector>
 
 #include "format.h"
-#include "ncurses_display.h"
 #include "system.h"
 
 using std::string;
@@ -78,7 +80,7 @@ void NCursesDisplay::DisplayProcesses(std::vector<Process> processes,
     mvwprintw(window, row, time_column,
               Format::ElapsedTime(processes[i].UpTime()).c_str());
     mvwprintw(window, row, command_column,
-              processes[i].Command().substr(0, window->_maxx - 46).c_str());
+              processes[i].Command().substr(0, getmaxx(window) - 46).c_str());
   }
 }
 
@@ -91,7 +93,7 @@ void NCursesDisplay::Display(System& system, int n) {
   int x_max{getmaxx(stdscr)};
   WINDOW* system_window = newwin(9, x_max - 1, 0, 0);
   WINDOW* process_window =
-      newwin(3 + n, x_max - 1, system_window->_maxy + 1, 0);
+      newwin(3 + n, x_max - 1, getmaxy(system_window) + 1, 0);
 
   while (1) {
     init_pair(1, COLOR_BLUE, COLOR_BLACK);

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -1,4 +1,7 @@
+#include "process.h"
+
 #include <unistd.h>
+
 #include <cctype>
 #include <iostream>
 #include <iterator>
@@ -10,7 +13,6 @@
 #include "linux_parser.h"
 #include "parser_consts.h"
 #include "parser_helper.h"
-#include "process.h"
 
 using namespace std;
 
@@ -24,10 +26,8 @@ Process::Process(int pid, long Hertz) : pid_(pid), Hertz_(Hertz) {
   starttime_ = stof(cpuNumbers[21]);
 }
 
-
 // Return this process's ID
 int Process::Pid() { return pid_; }
-
 
 // Return this process's CPU utilization
 double Process::CpuUtilization() {
@@ -40,16 +40,15 @@ double Process::CpuUtilization() {
   return cpu_usage;
 }
 
-
 // Return the command that generated this process
 string Process::Command() {
   string cmd = ParserHelper::GetValue<string>(to_string(pid_) +
                                               ParserConsts::kCmdlineFilename);
   size_t maxSize = 50;
-  if(cmd.size() > maxSize) {
+  if (cmd.size() > maxSize) {
     cmd.resize(maxSize - 3);
     cmd = cmd + "...";
-  }                                            
+  }
   return cmd;
 }
 
@@ -60,13 +59,11 @@ float Process::RawRam() {
   return memInKB;
 }
 
-
 // Return this process's memory utilization
 string Process::Ram() {
   float memInKB = RawRam();
   return Format::KBisMB(memInKB);
 }
-
 
 // Return the user (name) that generated this process
 string Process::User() {
@@ -76,7 +73,6 @@ string Process::User() {
   string user = LinuxParser::UserByUID(UID);
   return user;
 }
-
 
 // Return the age of this process (in seconds)
 long int Process::UpTime() {

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -1,4 +1,5 @@
 #include "processor.h"
+
 #include <sstream>
 #include <string>
 #include <vector>

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -1,12 +1,13 @@
+#include "system.h"
+
 #include <string>
 #include <vector>
 
+#include "all_processes.h"
+#include "format.h"
 #include "linux_parser.h"
 #include "process.h"
 #include "processor.h"
-#include "all_processes.h"
-#include "system.h"
-#include "format.h"
 
 using std::string;
 using std::vector;
@@ -14,7 +15,7 @@ using std::vector;
 // Return the system's CPU
 Processor& System::Cpu() { return cpu_; }
 
-//Return a container composed of the system's processes
+// Return a container composed of the system's processes
 All_Processes& System::Processes() { return processes_; }
 
 // Return the system's kernel identifier (string)
@@ -32,5 +33,5 @@ int System::RunningProcesses() { return LinuxParser::RunningProcesses(); }
 // Return the total number of processes on the system
 int System::TotalProcesses() { return LinuxParser::TotalProcesses(); }
 
-//Return the number of seconds since the system started running
+// Return the number of seconds since the system started running
 long int System::UpTime() { return LinuxParser::UpTime(); }


### PR DESCRIPTION
Fixed 2 errors:
    1. The project currently requires CMake version 2.6 which is outdated. Modern CMake versions (3.5+) have removed compatibility with versions < 3.5, resulting in the following error when building.

    2. causing errors because they access the internal structure of WINDOW.